### PR TITLE
chore: fix `empty()` method in `Span`.

### DIFF
--- a/Vectorisation/VecX/span.h
+++ b/Vectorisation/VecX/span.h
@@ -77,7 +77,7 @@ struct Span
 
 	bool empty() const
 	{
-		return m_extent = 0;
+		return m_extent == 0UL;
 	}
 
 	T* start() const
@@ -219,7 +219,7 @@ struct StridedSpan
 
 	bool empty() const
 	{
-		return m_extent = 0;
+		return m_extent == 0UL;
 	}
 
 	T* start() const


### PR DESCRIPTION
Just a tiny chore commit for the `empty()` method in `VecX`.